### PR TITLE
Add Host header support

### DIFF
--- a/checks/web_ping.go
+++ b/checks/web_ping.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"fmt"
 
 	"github.com/jonog/redalert/data"
 	"github.com/jonog/redalert/utils"
@@ -91,6 +92,14 @@ func (wp *WebPinger) ping() (data.Metrics, []byte, int, error) {
 	req.Header.Add("User-Agent", "Redalert/1.0")
 	for k, v := range wp.WebPingerConfig.Headers {
 		req.Header.Add(k, v)
+		if wp.Config.VerboseLogging != nil && *wp.Config.VerboseLogging {
+			wp.log.Printf("%s:%s", k, v)
+		}
+	}
+
+	host, ok := wp.WebPingerConfig.Headers["Host"]
+	if ok {
+		req.Host = host
 	}
 
 	resp, err := GlobalClient.Do(req)
@@ -121,5 +130,9 @@ func (wp *WebPinger) MetricInfo(metric string) MetricInfo {
 }
 
 func (wp *WebPinger) MessageContext() string {
+	host, ok := wp.WebPingerConfig.Headers["Host"]
+	if ok {
+		return fmt.Sprintf("%s, Host:%s", wp.WebPingerConfig.Address, host)
+	}
 	return wp.WebPingerConfig.Address
 }

--- a/checks/web_ping_test.go
+++ b/checks/web_ping_test.go
@@ -16,7 +16,8 @@ func testWebPingConfig(address string) []byte {
 							"config": {
 		             "address":"` + address + `",
 		             "headers": {
-		               "X-Api-Key": "ABCD1234"
+		               "X-Api-Key": "ABCD1234",
+		               "Host": "HostHeader"
 		             }
 		          },
 							"send_alerts": [
@@ -70,7 +71,7 @@ func TestWebPing_Check(t *testing.T) {
 
 func TestWebPing_Check_Headers(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, r.Header.Get("X-API-Key"))
+		fmt.Fprintf(w, "%s %s", r.Host, r.Header.Get("X-API-Key"))
 	}))
 	defer ts.Close()
 	var config Config
@@ -89,7 +90,7 @@ func TestWebPing_Check_Headers(t *testing.T) {
 	if data.Metadata["status_code"] != "200" {
 		t.Fatalf("expect: %#v, got: %#v", "200", data.Metadata["exit_status"])
 	}
-	if string(data.Response) != "ABCD1234" {
-		t.Fatalf("expect: %#v, got: %#v", "ABCD1234", string(data.Response))
+	if string(data.Response) != "HostHeader ABCD1234" {
+		t.Fatalf("expect: %#v, got: %#v", "HostHeader ABCD1234", string(data.Response))
 	}
 }


### PR DESCRIPTION
Setting custom Host header has no effect when using net/hhttp
package. [here](https://github.com/golang/go/issues/7682)

When the host header is set in the web ping configuration then the
req.Host field is set accordingly now.